### PR TITLE
Add support for P2 Resolved Posts plugin

### DIFF
--- a/style.css
+++ b/style.css
@@ -2069,6 +2069,69 @@ h2 .controls a#togglecomments:before {
   border-top: 1px solid #dddddd;
 }
 /**
+ * Plugins
+ */
+#main #postlist .meta .actions .state-normal {
+  display: block;
+  text-indent: -9999px;
+  position: relative;
+  height: 1em;
+  width: 1em;
+  display: inline-block;
+  color: #42a2ce;
+  width: 1.618em;
+  height: 1.618em;
+}
+#main #postlist .meta .actions .state-normal:before {
+  font-family: 'FontAwesome';
+  speak: none;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  margin: 0;
+  text-indent: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  content: "\f179";
+  color: #d2d9d9;
+  height: 1.618em;
+  width: 1.618em;
+  line-height: 1.618;
+}
+#main #postlist .meta .actions .state-normal:hover:before {
+  color: #4a5151;
+}
+#main #postlist li.hentry .actions a.state-normal:hover {
+  background-color: transparent !important;
+}
+#main #postlist .meta .actions .state-normal:before {
+  content: "\f071";
+}
+#main #postlist .hentry {
+  border-left: #ddd 1px solid !important;
+  padding-left: 1.618em !important;
+}
+#main #postlist .hentry.state-unresolved {
+  box-shadow: #E6000A 5px 0 0 inset;
+  border-left-color: #E6000A !important;
+}
+#main #postlist .hentry.state-resolved {
+  box-shadow: #8dc05d 5px 0 0 inset;
+  border-left-color: #8dc05d !important;
+}
+#main #postlist .hentry.state-resolved .actions a.p2-resolve-link {
+  background-color: #8dc05d !important;
+}
+.p2-resolved-posts-audit-log img {
+  width: 16px !important;
+}
+/**
  * Layout
  */
 @media only screen and (min-width: 768px) {

--- a/style.less
+++ b/style.less
@@ -1113,6 +1113,61 @@ h2 .controls {
 }
 
 /**
+ * Plugins
+ */
+
+// Resolved Posts Plugin
+
+// Slightly hacky cause we need to override inline <styles>
+#main #postlist {
+	.meta .actions .state-normal {
+		.ir;
+		display: inline-block;
+		color: @color_links;
+		//margin-right:.236em;
+		width:1.618em;
+		height:1.618em;
+		&:before {
+			.icon;
+			color: @color_body + #888;
+			height:1.618em;
+			width:1.618em;
+			line-height: 1.618;
+		}
+		&:hover {
+			&:before {
+				color: @color_body;
+			}
+		}
+	}
+	li.hentry .actions a.state-normal:hover {
+		background-color: transparent !important;
+	}
+	.meta .actions .state-normal:before {
+		content: "\f071";
+	}
+	.hentry {
+		border-left: #ddd 1px solid !important;
+		padding-left: 1.618em !important;
+	}
+	.hentry.state-unresolved {
+		box-shadow: #E6000A 5px 0 0 inset;
+		border-left-color: #E6000A !important;
+	}
+	.hentry.state-resolved {
+		box-shadow: #8dc05d 5px 0 0 inset;
+		border-left-color: #8dc05d !important;
+		.actions a.p2-resolve-link {
+			background-color: #8dc05d !important;
+		}
+	}
+}
+
+.p2-resolved-posts-audit-log img {
+	width: 16px !important;
+}
+
+/**
  * Layout
  */
 


### PR DESCRIPTION
Over on the Ghost company P2 we use a very handy little plugin called [P2 Resolved Posts](http://wordpress.org/plugins/p2-resolved-posts/) - which allows you to mark messages which need to be followed up on later.

Unfortunately this plugin conflicts like a proverbial motherfucker with Houston.

(showing hover state on all 3 posts)

![screen shot 2013-11-01 at 15 08 17](https://f.cloud.github.com/assets/120485/1453942/cd588ce4-42ff-11e3-85cf-547d37c313aa.png)
## PR In Action

This PR adds overrides for the default Resolved Posts styles to match the Houston theme, and fix the display issues. The plugin injects its shit via `<style>` tags - which really sucks - so a !important statements were necessary to get past the defaults.

We also hook into the fontawesome icon font to provide a slightly more pleasing default state for a normal post which needs a "flag as unresolved" CTA.

![screen shot 2013-11-01 at 15 10 09](https://f.cloud.github.com/assets/120485/1453964/2d4852ec-4300-11e3-9888-05ab8010a436.png)
## Other Issues

Houston's styles totally fuck the Unresolved Posts status hover menu thing. So this fixes that, too.

![screen shot 2013-11-01 at 15 09 16](https://f.cloud.github.com/assets/120485/1453945/d0983332-42ff-11e3-8ac8-f832ea52b1f0.png)

![screen](https://f.cloud.github.com/assets/120485/1453974/5b4d0642-4300-11e3-8a96-732bb73df588.png)
